### PR TITLE
[NEW] Introduces default job parameters (via "defaults" global variable)

### DIFF
--- a/lib/bricolage/job.rb
+++ b/lib/bricolage/job.rb
@@ -73,6 +73,7 @@ module Bricolage
     end
 
     def compile
+      param_vals_default = @param_decls.parse_default_values(@global_variables.get_force('defaults'))
       @job_class.invoke_parameters_filter(self)
 
       job_file_rest_vars = @param_vals ? @param_vals.variables : Variables.new
@@ -87,7 +88,7 @@ module Bricolage
         job_v_opt_vars
         #          v High precedence
       )
-      pvals = @param_decls.union_intermediate_values(*[@param_vals, @param_vals_opt].compact)
+      pvals = @param_decls.union_intermediate_values(*[param_vals_default, @param_vals, @param_vals_opt].compact)
       @params = pvals.resolve(@context, base_vars.resolve)
 
       # Then, expand SQL variables and check with declarations.

--- a/lib/bricolage/variables.rb
+++ b/lib/bricolage/variables.rb
@@ -38,6 +38,11 @@ module Bricolage
       var.value
     end
 
+    def get_force(name)
+      var = @vars[name]
+      var ? var.value : nil
+    end
+
     def []=(name, value)
       add Variable.new(name, value)
     end

--- a/test/home/subsys/rebuild.sql.job
+++ b/test/home/subsys/rebuild.sql.job
@@ -6,6 +6,7 @@
         s: s
     analyze: true
     vacuum-sort: true
+    #grant: false
 */
 
 insert into $dest_table

--- a/test/home/subsys/variable.yml
+++ b/test/home/subsys/variable.yml
@@ -1,0 +1,4 @@
+defaults:
+    grant:
+        privilege: "select"
+        to: "$test_group"


### PR DESCRIPTION
グローバル変数 defaults に値をセットしておくことで、あらゆるジョブクラスのデフォルト値を設定できるようにする。

例: (SUBSYS/variable.yml)
```
defaults:
    grant:
        privilege: select
        to: "group dwh_reader"
```
この設定をしておくことで、grantを持つ全ジョブがデフォルトでGRANTを発行するようになる。
なお、GRANTをしたくないジョブでは grant: false と書けばオフにできる。
grant以外でデフォルトをセットするとどうなるかは正直あんまり検討してない。