### PR TITLE
[FIX] Remove VACUUM lock when VACUUM failed

### DIFF
--- a/lib/bricolage/job.rb
+++ b/lib/bricolage/job.rb
@@ -130,6 +130,7 @@ module Bricolage
     end
 
     def execute
+      ENV['BRICOLAGE_PID'] = Process.pid.to_s
       logger = @context.logger
       logger.info "#{@context.environment} environment"
       result = logger.with_elapsed_time {

--- a/lib/bricolage/psqldatasource.rb
+++ b/lib/bricolage/psqldatasource.rb
@@ -186,7 +186,9 @@ module Bricolage
 
     # override
     def run
-      @ds.execute source
+      VacuumLock.using {
+        @ds.execute source
+      }
     end
 
     def run_explain

--- a/lib/bricolage/vacuumlock.rb
+++ b/lib/bricolage/vacuumlock.rb
@@ -1,4 +1,5 @@
 require 'bricolage/exception'
+require 'fileutils'
 
 module Bricolage
 
@@ -6,6 +7,7 @@ module Bricolage
     def enable_vacuum_lock?
       !!ENV['BRICOLAGE_VACUUM_LOCK']
     end
+    module_function :enable_vacuum_lock?
 
     DEFAULT_VACUUM_LOCK_FILE = '/tmp/bricolage.vacuum.lock'
     DEFAULT_VACUUM_LOCK_TIMEOUT = 3600   # 60min
@@ -31,7 +33,7 @@ module Bricolage
     def psql_serialize_vacuum_end
       if enable_vacuum_lock?
         path, timeout = vacuum_lock_parameters
-        "\\! rm #{path}"
+        "\\! rm -f #{path}"
       else
         ';'
       end
@@ -67,11 +69,41 @@ module Bricolage
         end
         sleep 1
         retry
-      rescue
-        raise
       end
     end
     module_function :create_vacuum_lock_file
+
+    def VacuumLock.using
+      return yield unless enable_vacuum_lock?
+      begin
+        yield
+      ensure
+        cleanup_vacuum_lock
+      end
+    end
+
+    def using_vacuum_lock(&block)
+      VacuumLock.using(&block)
+    end
+
+    def VacuumLock.cleanup_vacuum_lock
+      return unless enable_vacuum_lock?
+      path, timeout = vacuum_lock_parameters
+      if locking?(path)
+        $stderr.puts "remove VACUUM lock by #{Process.pid}"
+        FileUtils.rm_f path
+      end
+    end
+
+    def VacuumLock.locking?(path)
+      # do not check file existance, just read to avoid race condition
+      locker_pid = File.read(path).slice(/\[(\d+)\]/, 1).to_i
+      $stderr.puts "bricolage_pid: #{$$}, vacuum_locked_by: #{locker_pid}"
+      locker_pid == Process.pid
+    rescue
+      $stderr.puts "bricolage_pid: #{$$}, vacuum_locked_by: (none)"
+      false
+    end
   end
 
 end

--- a/libexec/create-lockfile
+++ b/libexec/create-lockfile
@@ -11,6 +11,9 @@ def main
   path, tm = ARGV
   timeout = [tm.to_i, MINIMUM_TIMEOUT].max
   create_lock_file path, timeout
+rescue
+  emit_error_to_psql
+  raise
 end
 
 def create_lock_file(path, timeout)
@@ -18,7 +21,7 @@ def create_lock_file(path, timeout)
   print_message "trying to create lock file: #{path} (psql #{parent_is_psql? ? 'detected' : 'NOT detected'})"
   begin
     File.open(path, File::WRONLY | File::CREAT | File::EXCL) {|f|
-      f.puts "#{Time.now}: created by process \##{Process.ppid}"
+      f.puts "#{Time.now}: created by create-lockfile (Bricolage pid [#{ENV['BRICOLAGE_PID']}])"
     }
   rescue Errno::EEXIST
     if Time.now - start_time > timeout
@@ -27,9 +30,6 @@ def create_lock_file(path, timeout)
     end
     sleep 3
     retry
-  rescue
-    emit_error_to_psql
-    raise
   end
   print_message "lock file created: #{path}"
 end

--- a/test/home/subsys/raw-vacuum.jobnet
+++ b/test/home/subsys/raw-vacuum.jobnet
@@ -1,0 +1,1 @@
+raw-vacuum


### PR DESCRIPTION
VACUUM自体が失敗したときロックファイルが残ってしまっていたので、必ず消すようにした。

## 詳細

そもそもなんでロックファイルを消していなかったかというと、psql経由でSQLを実行しているので、ロックをかけたかどうかBricolage側でわからなかったのが問題。VACUUMが終わったあとに他のプロセスがロックしたかもしれないので、ファイルがあるからといって無条件に消すわけにはいかなかった。

そこでこのpullreqではロックファイルにBricolageのPIDを記録することで、自分がロックをかけたのか判別できるようにして問題を解決した。自分がロックをかけていたなら、自分で消さないかぎりロックはかかったままのはずであるから、間違って他人のロックを外してしまう危険はない。

この修正を加えたことで、クリーンナップが失敗するケースはRubyがSEGVなどで突然死した場合と、SIGKILLで殺された場合（つまりRubyレベルのensureが動作しない状況）に限定された。
