### PR TITLE
td-export: Supports .sql.job

### DIFF
--- a/lib/bricolage/jobfile.rb
+++ b/lib/bricolage/jobfile.rb
@@ -26,6 +26,7 @@ module Bricolage
         rescue => err
           raise ParameterError, "#{path}: embedded job definition syntax error: #{err.message}"
         end
+        # avoid changing line number
         stripped_sql = sql.sub(%r{\A/\*.*?^\*/}m, "\n" * block.count("\n"))
         decls = make_sql_declarations(stripped_sql, values, path)
         stmt = SQLStatement.new(StringResource.new(sql, path), decls)

--- a/lib/bricolage/tddatasource.rb
+++ b/lib/bricolage/tddatasource.rb
@@ -55,7 +55,7 @@ module Bricolage
       def source
         buf = StringIO.new
         buf.puts command_args(new_tmpfile_path).join(' ') + " <<EndTDSQL"
-        buf.puts @statement.source
+        buf.puts @statement.stripped_source
         buf.puts 'EndTDSQL'
         buf.string
       end
@@ -67,7 +67,7 @@ module Bricolage
           raise JobFailure, "target file exists: #{@path.inspect}"
         end
         puts @statement.source
-        td_result = make_tmpfile(@statement.source) {|query_path|
+        td_result = make_tmpfile(@statement.stripped_source) {|query_path|
           ds.exec(*command_args(query_path))
         }
         if @gzip


### PR DESCRIPTION
TDジョブクラスでも.sql.jobをサポートする

ref: #19 