### PR TITLE
Supports encrypted S3 data source

### DIFF
--- a/lib/bricolage/psqldatasource.rb
+++ b/lib/bricolage/psqldatasource.rb
@@ -499,6 +499,8 @@ module Bricolage
           "#{@name} '#{@value}'"
         when Integer   # maxerror 10
           "#{@name} #{@value}"
+        when nil       # (explicitly disable boolean options)
+          ''
         else
           raise ParameterError, "unsupported type of option value for #{@name}: #{@value.inspect}"
         end

--- a/lib/bricolage/s3datasource.rb
+++ b/lib/bricolage/s3datasource.rb
@@ -10,13 +10,14 @@ module Bricolage
 
     def initialize(endpoint: 's3-ap-northeast-1.amazonaws.com',
         bucket: nil, prefix: nil,
-        access_key_id: nil, secret_access_key: nil,
+        access_key_id: nil, secret_access_key: nil, master_symmetric_key: nil,
         s3cfg: nil)
       @endpoint = endpoint
       @bucket = bucket
       @prefix = (prefix && prefix.empty?) ? nil : prefix
       @access_key_id = access_key_id
       @secret_access_key = secret_access_key
+      @master_symmetric_key = master_symmetric_key
       @s3cfg = s3cfg
       @configurations = @s3cfg ? load_configurations(@s3cfg) : nil
     end
@@ -31,7 +32,11 @@ module Bricolage
 
     # For Redshift
     def credential_string
-      "aws_access_key_id=#{access_key};aws_secret_access_key=#{secret_key}"
+      [
+        "aws_access_key_id=#{access_key}",
+        "aws_secret_access_key=#{secret_key}",
+        (@master_symmetric_key && "master_symmetric_key=#{@master_symmetric_key}")
+      ].compact.join(';')
     end
 
     def access_key
@@ -57,6 +62,10 @@ module Bricolage
         end
       end
       h
+    end
+
+    def encrypted?
+      !!@master_symmetric_key
     end
 
     #

--- a/test/home/subsys/load.job
+++ b/test/home/subsys/load.job
@@ -1,0 +1,9 @@
+class: load
+drop: true
+table-def: search_backends.ct
+dest-table: $test_schema.search_backends
+src-file: /search_backends/search_backends.json.gz
+format: json
+options:
+    gzip: true
+    #encrypted: null


### PR DESCRIPTION
暗号化されたS3オブジェクトをロードできるようにする。

ref: #42 

## 仕様

- s3 data sourceにmaster_symmetric_keyパラメーターを追加する
- master_symmetric_keyが設定されたs3 data sourceからロードする場合はcredential文字列にも自動的にmaster_symmetric_keyを追加する
- また同data sourceからロードするジョブではencryptedオプションが自動で有効になる（いちおう、encrypted: nullで明示的にオフにできる）