### PR TITLE
Compile %i as uuid for file name pattern

### DIFF
--- a/jobclass/streaming_load.rb
+++ b/jobclass/streaming_load.rb
@@ -414,6 +414,7 @@ class StreamingLoadJobClass < RubyJobClass
         when '%S' then '(?<second>\\d{2})'
         when /\A%(\d+)N\z/ then "(?<nanosecond>\\d{#{$1}})"
         when '%Q' then '(?<seq>\\d+)'
+        when '%i' then '(?<uuid>[a-fA-F0-9]{8}-([a-fA-F0-9]{4}-){3}[a-fA-F0-9]{12})'
         when '%*' then '[^/]*'
         when '%%' then '%'
         when /\A%/ then raise ParameterError, "unknown time format in s3.file_name config: #{op.inspect}"

--- a/test/test_c_streaming_load.rb
+++ b/test/test_c_streaming_load.rb
@@ -6,8 +6,8 @@ module Bricolage
   class TestStreamingLoadJobClass_S3Queue < Test::Unit::TestCase
     def test_compile_name_pattern
       q = StreamingLoadJobClass::S3Queue.new(data_source: nil, queue_path: nil, persistent_path: nil, file_name: nil, logger: nil)
-      re = q.compile_name_pattern("%*%Y%m%d-%H%M_%Q.gz")
-      assert_equal /\A[^\/]*(?<year>\d{4})(?<month>\d{2})(?<day>\d{2})\-(?<hour>\d{2})(?<minute>\d{2})_(?<seq>\d+)\.gz\z/, re
+      re = q.compile_name_pattern("%*%Y%m%d-%H%M_%Q_%i.gz")
+      assert_equal /\A[^\/]*(?<year>\d{4})(?<month>\d{2})(?<day>\d{2})\-(?<hour>\d{2})(?<minute>\d{2})_(?<seq>\d+)_(?<uuid>[a-fA-F0-9]{8}-([a-fA-F0-9]{4}-){3}[a-fA-F0-9]{12})\.gz\z/, re
     end
   end
 end


### PR DESCRIPTION
Since I'm using path including `uuid_flush` (of fluent-plugin-s3) as S3 queue for streaming_load, I'd be good to have pattern for uuid defined in RFC4122.
Avoiding `%U` or `%u` which are used in `strftime`, I added `%i` pattern for uuid.