### PR TITLE
[load, streaming_load] "encryption" option is not needed for SSE-KMS

### DIFF
--- a/lib/bricolage/psqldatasource.rb
+++ b/lib/bricolage/psqldatasource.rb
@@ -472,9 +472,6 @@ module Bricolage
     end
 
     def provide_defaults(src_ds)
-      if src_ds.encrypted? and not key?('encrypted')
-        self['encrypted'] = true
-      end
     end
 
     class Option


### PR DESCRIPTION
encryptionオプションはclient-side encryption用なので不要