### PR TITLE
[Fix] Redis export exit with error when a key to set already exists.

### DIFF
--- a/lib/bricolage/postgresconnection.rb
+++ b/lib/bricolage/postgresconnection.rb
@@ -43,9 +43,9 @@ module Bricolage
         @logger.info "[#{@ds.name}] #{declare_cursor}"
         @connection.exec(declare_cursor)
       elsif !@cursor.nil? && cursor.nil?
-        raise "Cursor in use"
+        raise "Cannot declare new cursor. Cursor in use: #{@cursor}"
       elsif @cursor != cursor
-        raise "Invalid cursor"
+        raise "Specified cursor not exists. Specified: #{cursor}, Current: #{@cursor}"
       end
       fetch = "fetch #{fetch_size} in #{@cursor}"
       @logger.info "[#{@ds.name}] #{fetch}" if cursor.nil?

--- a/lib/bricolage/redisdatasource.rb
+++ b/lib/bricolage/redisdatasource.rb
@@ -8,15 +8,15 @@ module Bricolage
   class RedisDataSource < DataSource
     declare_type 'redis'
 
-    def initialize(host: 'localhost', port: 6380, **opts)
+    def initialize(host: 'localhost', port: 6380, **options)
       @host = host
       @port = port
-      @options = opts
+      @options = options
     end
 
     attr_reader :host
     attr_reader :port
-    attr_reader :opts
+    attr_reader :options
 
     def new_task
       RedisTask.new(self)

--- a/test/home/subsys/redis_export2.job
+++ b/test/home/subsys/redis_export2.job
@@ -1,0 +1,8 @@
+class: redis-export
+src-ds: sql
+src-tables:
+    user_cook_recipes: $test_schema.user_cook_recipes
+dest-ds: redis
+key-column: user_id
+encode: json
+expire: 60


### PR DESCRIPTION
Problem: The redis-export jobclass exit with error when a key to set already exists in DB.
Solution: Remove error checking which is not working and needless.

Also include...
- Fix parameter name (typo)
- Improve error message
- Add test job