### PR TITLE
Add my-import jobclass

### DIFF
--- a/jobclass/my-import.rb
+++ b/jobclass/my-import.rb
@@ -1,0 +1,104 @@
+require 'bricolage/psqldatasource'
+require 'bricolage/mysqldatasource'
+
+JobClass.define('my-import') {
+  parameters {|params|
+    # S3Export
+    params.add SrcTableParam.new(optional: false)
+    params.add DataSourceParam.new('mysql', 'src-ds', 'Source data source.')
+    params.add SQLFileParam.new(optional: true)
+    params.add DataSourceParam.new('s3', 's3-ds', 'Temporary file storage.')
+    params.add DestFileParam.new('s3-prefix', 'PREFIX', 'Temporary S3 prefix.')
+    params.add KeyValuePairsParam.new('dump-options', 'KEY:VALUE', 'dump options.', optional: true)
+
+    # Load
+    params.add DestTableParam.new(optional: false)
+    params.add DataSourceParam.new('sql', 'dest-ds', 'Destination data source.')
+    params.add KeyValuePairsParam.new('options', 'OPTIONS', 'Loader options.',
+        optional: true, default: PSQLLoadOptions.new,
+        value_handler: lambda {|value, ctx, vars| PSQLLoadOptions.parse(value) })
+    params.add SQLFileParam.new('table-def', 'PATH', 'Create table file.')
+
+    # Misc
+    params.add OptionalBoolParam.new('analyze', 'ANALYZE table after SQL is executed.', default: true)
+    params.add OptionalBoolParam.new('vacuum', 'VACUUM table after SQL is executed.')
+    params.add OptionalBoolParam.new('vacuum-sort', 'VACUUM SORT table after SQL is executed.')
+    params.add KeyValuePairsParam.new('grant', 'KEY:VALUE', 'GRANT table after SQL is executed. (required keys: privilege, to)')
+
+    # All
+    params.add OptionalBoolParam.new('export', 'Runs EXPORT task.')
+    params.add OptionalBoolParam.new('put', 'Runs PUT task.')
+    params.add OptionalBoolParam.new('load', 'Runs LOAD task.')
+    params.add OptionalBoolParam.new('gzip', 'Compress Temporary files.')
+  }
+
+  declarations {|params|
+    decls = sql_statement(params).declarations
+    decls.declare 'dest-table', nil
+    decls
+  }
+
+  script {|params, script|
+    run_all = !params['export'] && !params['put'] && !params['load']
+
+    # S3Export
+    if params['export'] || run_all
+      script.task(params['src-ds']) {|task|
+        task.s3export params['src-tables'].keys.first,
+                      sql_statement(params),
+                      params['s3-ds'],
+                      params['s3-prefix'],
+                      params['gzip'],
+                      dump_options: params['dump-options']
+      }
+    end
+
+    # Load
+    if params['load'] || run_all
+      script.task(params['dest-ds']) {|task|
+        prev_table = '${dest_table}_old'
+        work_table = '${dest_table}_wk'
+
+        # CREATE
+        task.drop_force prev_table
+        task.drop_force work_table
+        task.exec params['table-def'].replace(/\$\{?dest_table\}?\b/, work_table)
+
+        # COPY
+        task.load params['s3-ds'], params['s3-prefix'], work_table,
+            'json', nil, params['options'].merge('gzip' => params['gzip'])
+
+        # VACUUM, ANALYZE, GRANT
+        task.vacuum_if params['vacuum'], params['vacuum-sort'], work_table
+        task.analyze_if params['analyze'], work_table
+        task.grant_if params['grant'], work_table
+
+        # RENAME
+        task.create_dummy_table '${dest_table}'
+        task.transaction {
+          task.rename_table params['dest-table'].to_s, "#{params['dest-table'].name}_old"
+          task.rename_table work_table, params['dest-table'].name
+        }
+      }
+    end
+  }
+
+  def sql_statement(params)
+    return params['sql-file'] if params['sql-file']
+    srcs = params['src-tables']
+    raise ParameterError, "src-tables must be singleton when no sql-file is given" unless srcs.size == 1
+    src_table_var = srcs.keys.first
+    query = add_place_holder(params, "select * from $#{src_table_var}")
+    stmt = SQLStatement.for_string(query)
+    stmt.declarations = Declarations.new({src_table_var => src_table_var})
+    stmt
+  end
+
+  def add_place_holder(params, query)
+    if params['dump-options']['partition_column']
+      return query + " WHERE @PARTITION_CONDITION@;"
+    else
+      return query + ";"
+    end
+  end
+}

--- a/lib/bricolage/mysqldatasource.rb
+++ b/lib/bricolage/mysqldatasource.rb
@@ -15,6 +15,8 @@ module Bricolage
       @client = nil
     end
 
+    attr_reader :mysql_options
+
     def host
       @mysql_options[:host]
     end
@@ -169,6 +171,110 @@ module Bricolage
         else
           File.open(path, 'w', &block)
         end
+      end
+    end
+
+    def s3export(table, stmt, s3ds, prefix, gzip, dump_options)
+      options = dump_options.nil? ? {} : dump_options[:dump_options]
+      add S3Export.new(table, stmt, s3ds, prefix, gzip: gzip,
+                       format: options['format'],
+                       partition_column: options['partition_column'],
+                       partition_number: options['partition_number'],
+                       write_concurrency: options['write_concurrency'],
+                       rotation_size: options['rotation_size'],
+                       delete_objects: options['delete_objects'],
+                       object_key_delimiter: options['object_key_delimiter'])
+    end
+
+    class S3Export < Export
+
+      def initialize(table, stmt, s3ds, prefix, gzip: true,
+                     format: "json",
+                     partition_column: nil,
+                     partition_number: 4,
+                     write_concurrency: 4,
+                     rotation_size: nil,
+                     delete_objects: false,
+                     object_key_delimiter: nil)
+        @table = table
+        @statement = stmt
+        @s3ds = s3ds
+        @prefix = build_prefix @s3ds.prefix, prefix
+        @format = format
+        @gzip = gzip
+        @partition_column = partition_column
+        @partition_number = partition_number
+        @write_concurrency = write_concurrency
+        @rotation_size = rotation_size
+        @delete_objects = delete_objects
+        @object_key_delimiter = object_key_delimiter
+      end
+
+      def s3export
+        cmd = build_cmd command_parameters
+        ds.logger.info '[CMD] ' + cmd
+        Open3.popen2e(cmd) do |input, output, thread|
+          input.close
+          output.each do |line|
+            puts line
+          end
+          unless thread.value.success?
+            raise JobFailure, "#{cmd} failed (status #{thread.value.to_i})"
+          end
+        end
+      end
+
+      def commad_parameters()
+        params = {jar: mys3dump_path.to_s, h: ds.host, P: ds.port.to_s, D: ds.database, u: ds.username, p: ds.password,
+                   o: connection_property, t: @table, q: @statement.stripped_source.chop,
+                   'Daws.accessKeyId': @s3ds.access_key, 'Daws.secretKey': @s3ds.secret_key, b: @s3ds.bucket.name, x: @prefix}
+        params[:f] = @format if @format
+        params[:C] = nil if @gzip
+        params[:c] = @partition_column if @partition_column
+        params[:n] = @partition_number if @partition_number
+        params[:w] = @write_concurrency if @write_concurrency
+        params[:r] = @rotation_size if @rotation_size
+        params[:d] = nil if @delete_objects
+        params[:k] = @object_key_delimiter if @object_key_delimiter
+        params
+      end
+
+      def connection_property()
+        map = {}
+        puts ds.mysql_params
+        map[:encoding] = 'useUnicode=true&characterEncoding'
+        map[:read_timeout] = 'netTimeoutForStreamingResults'
+        map[:connect_timeout] = 'connectTimeout'
+        map[:reconnect] = 'autoReconnect'
+        property = ""
+        amp = ""
+        ds.mysql_options.each do |k, v|
+          property += amp + map[k] + '=' + v if map[k]
+          amp = '&'
+        end
+        property
+      end
+
+      def build_prefix(ds_prefix, pm_prefix)
+        ((ds_prefix || "") + "//" +  (pm_prefix.to_s || "")).gsub(%r<\A/>, '').gsub(%r<//>, '/')
+      end
+
+      def mys3dump_path
+        Pathname(__dir__).parent.parent + "libexec/mys3dump.jar"
+      end
+
+      def run
+        s3export
+        JobResult.success
+      end
+
+      def build_cmd(options)
+        cmd = "java"
+        options.each do |k, v|
+          cmd = "#{cmd} -#{k}"
+          cmd += %Q( "#{v}") if v
+        end
+        cmd
       end
     end
 

--- a/lib/bricolage/mysqldatasource.rb
+++ b/lib/bricolage/mysqldatasource.rb
@@ -216,7 +216,7 @@ module Bricolage
       end
 
       def bind(*args)
-        @statement.bind(*args)
+        @statement.bind(*args) if @statement
       end
 
       def s3export
@@ -234,9 +234,9 @@ module Bricolage
       end
 
       def command_parameters
-        params = {jar: mys3dump_path.to_s, h: ds.host, P: ds.port.to_s, D: ds.database, u: ds.username, p: ds.password,
-                   o: connection_property, t: @table, q: @statement.stripped_source.chop,
+        params = {jar: mys3dump_path.to_s, h: ds.host, P: ds.port.to_s, D: ds.database, u: ds.username, p: ds.password, o: connection_property, t: @table,
                    'Daws.accessKeyId': @s3ds.access_key, 'Daws.secretKey': @s3ds.secret_key, b: @s3ds.bucket.name, x: @prefix}
+        params[:q] = @statement.stripped_source.chop if @statement
         params[:f] = @format if @format
         params[:C] = nil if @gzip
         params[:c] = @partition_column if @partition_column

--- a/test/home/subsys/my-import.job
+++ b/test/home/subsys/my-import.job
@@ -1,0 +1,32 @@
+class: my-import
+src-ds: mysql
+src-tables:
+    users: main.users
+s3-ds: s3
+s3-prefix: shimpeko/test-abc-
+gzip: true
+dump-options:
+    partition_column: id  
+    partition_number: 8
+    write_concurrency: 16
+    rotation_size: 16000000
+    delete_objects: true
+dest-ds: sql
+dest-table: $test_schema.users
+table-def: users.ct
+options:
+    statupdate: false
+    compupdate: false
+    maxerror: 3
+    acceptinvchars: " "
+    #trimblanks: true
+    #truncatecolumns: true
+    ## datetime
+    #acceptanydate: true
+    #dateformat: "auto"
+    #timeformat: "auto"
+vacuum-sort: true
+analyze: true
+grant:
+    privilege: select
+    to: "$test_group"

--- a/test/home/subsys/my-import.job
+++ b/test/home/subsys/my-import.job
@@ -6,7 +6,7 @@ s3-ds: s3
 s3-prefix: shimpeko/test-abc-
 gzip: true
 dump-options:
-    partition_column: id  
+    partition_column: id
     partition_number: 8
     write_concurrency: 16
     rotation_size: 16000000

--- a/test/home/subsys/users.ct
+++ b/test/home/subsys/users.ct
@@ -1,0 +1,13 @@
+--dest-table: users
+
+create table $dest_table
+( id int encode delta
+, user_name varchar(1000) encode lzo
+, birthday date encode lzo
+, zip varchar(255) encode lzo
+, created_at timestamp encode lzo
+, updated_at timestamp encode lzo
+)
+distkey (id)
+sortkey (id)
+;


### PR DESCRIPTION
Add my-import jobclass which improve performance of data importing from mysql.

"my-import" dumps MySQL table directly to S3 without writing data on local storage.
Please note this jobclass requires decent amount of memory, a few GB, depends on number of writer concurrency.

**options**
`src-table`: source MySQL table name
`src-ds`: source MySQL data source
`sql-fil`e: MySQL query (optional)
`s3-ds`: S3 data source to store tmp data
`s3-prefix`: S3 prefix
`dump-options`: see below
`format`: json, tsv, csv. default: json
`partition_column`: column to partition source table (required to enable parallel read). no default.
`partition_number`: number of partitions = number of reader concurrency. default: 4
`writer_concurrency`: writer concurrency. default: 4
`rotation_size`: Preferred S3 Object size in byte. Start writing to new object when exceed. default: 6710886
`delete_objects`: Delete existing object with prefix. default: false