### PR TITLE
[streaming_load][CHANGE] Reuse fixed temporary log table

### DIFF
--- a/jobclass/streaming_load.rb
+++ b/jobclass/streaming_load.rb
@@ -261,21 +261,13 @@ class StreamingLoadJobClass < RubyJobClass
 
     def create_tmp_log_table(conn, log_url)
       target_table = log_table_wk
-      execute_update conn, "create table #{target_table} (like #{@log_table});"
+      execute_update conn, "truncate #{target_table};"
       execute_update conn, load_log_copy_stmt(target_table, log_url, @src.credential_string)
-      begin
-        yield target_table
-      ensure
-        begin
-          execute_update conn, "drop table #{target_table}"
-        rescue PostgreSQLException => ex
-          @logger.error ex.message + " (ignored)"
-        end
-      end
+      yield target_table
     end
 
     def log_table_wk
-      "#{@log_table}_tmp#{Process.pid}"
+      "#{@log_table}_wk"
     end
 
     def load_log_copy_stmt(target_table, log_url, credential_string)


### PR DESCRIPTION
streaming_loadジョブクラスでジョブ起動のたびに一時ログテーブル xxxx_l_tmpNNNN をdrop-createしていたのをやめて、常設の xxxx_l_wk を使うようにします。これにともない、streaming_loadでは xxxx_wk, xxxx_l, xxxx_l_wk の3つの補助テーブルが必須になります。

やめる理由は、drop, createなどのDDLが異常に遅くなる現象が発生しているため。これが原因かどうかはわかっていないものの、現在原因がまったくわからないのでとりあえずやってみる。

ただ、ワークテーブルが増えてきてさすがに面倒なので、現在開発中の streaming_load v3（独立ストリーミングローダー）で全テーブルまとめて処理できるようにする予定。
