### PR TITLE
Fix S3Export command parameter key specification in MySQLDataSource

### DIFF
--- a/lib/bricolage/mysqldatasource.rb
+++ b/lib/bricolage/mysqldatasource.rb
@@ -235,7 +235,7 @@ module Bricolage
 
       def command_parameters
         params = {jar: mys3dump_path.to_s, h: ds.host, P: ds.port.to_s, D: ds.database, u: ds.username, p: ds.password, o: connection_property, t: @table,
-                   'Daws.accessKeyId': @s3ds.access_key, 'Daws.secretKey': @s3ds.secret_key, b: @s3ds.bucket.name, x: @prefix}
+                   'Daws.accessKeyId' => @s3ds.access_key, 'Daws.secretKey' => @s3ds.secret_key, b: @s3ds.bucket.name, x: @prefix}
         params[:q] = @statement.stripped_source.chop if @statement
         params[:f] = @format if @format
         params[:C] = nil if @gzip


### PR DESCRIPTION
ハッシュのキーが文字列であるにも関わらず、省略記法で書かれているため修正します
