### PR TITLE
streaming_load: FIX?: disable compupdate

### DIFF
--- a/jobclass/streaming_load.rb
+++ b/jobclass/streaming_load.rb
@@ -222,6 +222,7 @@ class StreamingLoadJobClass < RubyJobClass
         from '#{manifest_url}'
         credentials '#{@src.credential_string}'
         manifest
+        compupdate false
         statupdate false
         #{@load_options}
       ;).gsub(/\s+/, ' ').strip
@@ -277,6 +278,7 @@ class StreamingLoadJobClass < RubyJobClass
         credentials '#{credential_string}'
         delimiter ','
         removequotes
+        compupdate false
       ;).gsub(/\s+/, ' ').strip
     end
 


### PR DESCRIPTION
いくつかのRedshiftクラスターにおいて、COPYのanalyze compression phaseで以下のエラーが発生する謎のバグに出会ったので回避を試みる
```
  -----------------------------------------------
  error:  Assert
  code:      1000
  context:   (fieldstr - curr) < len - Error: (fieldstr - curr):0 is greater than len:0
  query:     3805233
  location:  tbl_trans.cpp:1171
  process:   query1_57 [pid=57628]
  -----------------------------------------------
```