### PR TITLE
複数テーブルのタスクのロードを1トランザクションと、テーブル毎のロードインターバルのサポート

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.gem
 *.rbc
-.vscode
 .bundle
 .config
 coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 *.rbc
+.vscode
 .bundle
 .config
 coverage

--- a/lib/bricolage/sqsdatasource.rb
+++ b/lib/bricolage/sqsdatasource.rb
@@ -28,7 +28,7 @@ module Bricolage
 
     def client
       @client ||= begin
-        c = @noop ? DummySQSClient.new : Aws::SQS::Client.new(region: @region, access_key_id: @access_key, secret_access_key: @secret_key)
+        c = @noop ? DummySQSClient.new : Aws::SQS::Client.new(region: @region, access_key_id: @access_key_id, secret_access_key: @secret_access_key)
         SQSClientWrapper.new(c, logger: logger)
       end
     end

--- a/lib/bricolage/streamingload/dispatcher.rb
+++ b/lib/bricolage/streamingload/dispatcher.rb
@@ -35,7 +35,7 @@ module Bricolage
           data_source: ctx.get_data_source('sql', 'sql'),
           control_data_source: ctx.get_data_source('s3', config.fetch('ctl-ds')),
           default_buffer_size_limit: 500,
-          default_load_interval: 300,
+          default_load_interval: 1200, -- 20min
           process_flush_interval: 60,
           context: ctx
         )

--- a/lib/bricolage/streamingload/dispatcher.rb
+++ b/lib/bricolage/streamingload/dispatcher.rb
@@ -35,7 +35,7 @@ module Bricolage
           data_source: ctx.get_data_source('sql', 'sql'),
           control_data_source: ctx.get_data_source('s3', config.fetch('ctl-ds')),
           default_buffer_size_limit: 500,
-          default_load_interval: 1200, -- 20min
+          default_load_interval: 1200,
           process_flush_interval: 60,
           context: ctx
         )

--- a/lib/bricolage/streamingload/dispatcher.rb
+++ b/lib/bricolage/streamingload/dispatcher.rb
@@ -23,6 +23,7 @@ module Bricolage
           exit 1
         end
         config_path, * = opts.rest_arguments
+        set_log_path opts.log_file_path if opts.log_file_path
 
         config = YAML.load(File.read(config_path))
         ctx = Context.for_application('.', environment: opts.environment)
@@ -50,7 +51,6 @@ module Bricolage
 
         Process.daemon(true) if opts.daemon?
         create_pid_file opts.pid_file_path if opts.pid_file_path
-        set_log_path opts.log_file_path if opts.log_file_path
         dispatcher.set_processflush_timer
         dispatcher.event_loop
       end

--- a/lib/bricolage/streamingload/dispatcher.rb
+++ b/lib/bricolage/streamingload/dispatcher.rb
@@ -24,7 +24,7 @@ module Bricolage
         config_path, * = opts.rest_arguments
 
         config = YAML.load(File.read(config_path))
-        ctx = Context.for_application('.')
+        ctx = Context.for_application('.', environment: opts.environment)
         event_queue = ctx.get_data_source('sqs', config.fetch('event-queue-ds'))
         task_queue = ctx.get_data_source('sqs', config.fetch('task-queue-ds'))
 
@@ -134,6 +134,9 @@ module Bricolage
         opts.on('--task-id=ID', 'Execute oneshot load task (implicitly disables daemon mode).') {|task_id|
           @task_id = task_id
         }
+        opts.on('-e', '--environment=NAME', "Sets execution environment [default: #{Context::DEFAULT_ENV}]") {|env|
+          @environment = env
+        }
         opts.on('--daemon', 'Becomes daemon in server mode.') {
           @daemon = true
         }
@@ -161,7 +164,7 @@ module Bricolage
         raise OptionError, err.message
       end
 
-      attr_reader :rest_arguments
+      attr_reader :rest_arguments, :environment
 
       def daemon?
         @daemon

--- a/lib/bricolage/streamingload/dispatcher.rb
+++ b/lib/bricolage/streamingload/dispatcher.rb
@@ -33,8 +33,8 @@ module Bricolage
           data_source: ctx.get_data_source('sql', 'sql'),
           default_buffer_size_limit: 500,
           default_load_interval: 300,
-          flush_process_interval: 60,
-          ctx: ctx
+          process_flush_interval: 60,
+          context: ctx
         )
 
         url_patterns = URLPatterns.for_config(config.fetch('url_patterns'))
@@ -99,14 +99,14 @@ module Bricolage
       end
 
       def handle_processflush(e)
-        load_tasks = @object_buffer.flush_required_buffers
+        load_tasks = @object_buffer.process_flush
         load_tasks.each {|load_task| delete_events(load_task.source_events) }
         @event_queue.delete_message(e)
         set_processflush_timer
       end
 
       def set_processflush_timer
-        @event_queue.send_message ProcessFlushEvent.create(delay_seconds: @object_buffer.flush_process_interval)
+        @event_queue.send_message ProcessFlushEvent.create(delay_seconds: @object_buffer.process_flush_interval)
       end
 
       def delete_events(events)

--- a/lib/bricolage/streamingload/dispatcher.rb
+++ b/lib/bricolage/streamingload/dispatcher.rb
@@ -35,7 +35,7 @@ module Bricolage
           data_source: ctx.get_data_source('sql', 'sql'),
           control_data_source: ctx.get_data_source('s3', config.fetch('ctl-ds')),
           default_buffer_size_limit: 500,
-          default_load_interval: 1200,
+          default_load_interval: 900,
           process_flush_interval: 60,
           context: ctx
         )

--- a/lib/bricolage/streamingload/dispatcher.rb
+++ b/lib/bricolage/streamingload/dispatcher.rb
@@ -109,7 +109,8 @@ module Bricolage
       end
 
       def handle_flush(e)
-        @object_buffer[e.table_name].request_flush
+        # might be nil in rare case ( stop -> del job file -> start )
+        @object_buffer[e.table_name].request_flush if @object_buffer[e.table_name]
         @event_queue.delete_message(e)
       end
 

--- a/lib/bricolage/streamingload/dispatcher.rb
+++ b/lib/bricolage/streamingload/dispatcher.rb
@@ -32,6 +32,7 @@ module Bricolage
         object_buffer = ObjectBuffer.new(
           task_queue: task_queue,
           data_source: ctx.get_data_source('sql', 'sql'),
+          control_data_source: ctx.get_data_source('s3', config.fetch('ctl-ds')),
           default_buffer_size_limit: 500,
           default_load_interval: 300,
           process_flush_interval: 60,

--- a/lib/bricolage/streamingload/dispatcher.rb
+++ b/lib/bricolage/streamingload/dispatcher.rb
@@ -83,6 +83,10 @@ module Bricolage
         end
         obj = e.loadable_object(@url_patterns)
         buf = @object_buffer[obj.qualified_name]
+        unless buf
+          @event_queue.delete_message(e)
+          return
+        end
         if buf.empty?
           set_flush_timer obj.qualified_name, buf.load_interval
         end

--- a/lib/bricolage/streamingload/dispatcher.rb
+++ b/lib/bricolage/streamingload/dispatcher.rb
@@ -48,6 +48,7 @@ module Bricolage
 
         Process.daemon(true) if opts.daemon?
         create_pid_file opts.pid_file_path if opts.pid_file_path
+        dispatcher.set_processflush_timer
         dispatcher.event_loop
       end
 
@@ -67,7 +68,6 @@ module Bricolage
       end
 
       def event_loop
-        set_processflush_timer
         @event_queue.main_handler_loop(handlers: self, message_class: Event)
       end
 
@@ -103,9 +103,9 @@ module Bricolage
       end
 
       def handle_processflush(e)
+        @event_queue.delete_message(e)
         load_tasks = @object_buffer.process_flush
         load_tasks.each {|load_task| delete_events(load_task.source_events) }
-        @event_queue.delete_message(e)
         set_processflush_timer
       end
 

--- a/lib/bricolage/streamingload/event.rb
+++ b/lib/bricolage/streamingload/event.rb
@@ -9,6 +9,7 @@ module Bricolage
       def Event.get_concrete_class(msg, rec)
         case
         when rec['eventName'] == 'shutdown' then ShutdownEvent
+        when rec['eventName'] == 'processflush' then ProcessFlushEvent
         when rec['eventName'] == 'flush' then FlushEvent
         when rec['eventSource'] == 'aws:s3'
           S3ObjectEvent
@@ -48,34 +49,42 @@ module Bricolage
 
     class FlushEvent < Event
 
-      def FlushEvent.create(delay_seconds:, table_name:, head_url:)
-        super name: 'flush', delay_seconds: delay_seconds, table_name: table_name, head_url: head_url
+      def FlushEvent.create(delay_seconds:, table_name:)
+        super name: 'flush', delay_seconds: delay_seconds, table_name: table_name
       end
 
       def FlushEvent.parse_sqs_record(msg, rec)
         {
-          table_name: rec['tableName'],
-          head_url: rec['headUrl']
+          table_name: rec['tableName']
         }
       end
 
       alias message_type name
 
-      def init_message(table_name:, head_url:)
+      def init_message(table_name:)
         @table_name = table_name
-        @head_url = head_url
       end
 
       attr_reader :table_name
-      attr_reader :head_url
 
       def body
         obj = super
         obj['tableName'] = @table_name
-        obj['headUrl'] = @head_url
         obj
       end
 
+    end
+
+    class ProcessFlushEvent < Event
+
+      def ProcessFlushEvent.create(delay_seconds:)
+        super name: 'processflush', delay_seconds: delay_seconds
+      end
+
+      alias message_type name
+
+      def init_message(dummy)
+      end
     end
 
 

--- a/lib/bricolage/streamingload/loader.rb
+++ b/lib/bricolage/streamingload/loader.rb
@@ -55,6 +55,7 @@ module Bricolage
           @connection.transaction {
             commit_job_result
           }
+          return
         end
         ManifestFile.create(
           @params.ctl_bucket,

--- a/lib/bricolage/streamingload/loader.rb
+++ b/lib/bricolage/streamingload/loader.rb
@@ -53,8 +53,9 @@ module Bricolage
           # These result record MUST be written in the same transaction.
           # DO NOT raise exception here
           if already_processed
-            write_job_error 'failure', "task is already processed by other jobs"
-            success = false
+            # Skip already processed task (may happen with second and later "duplicated" sqs messages)
+            #FIXME May leave object unprocessed when running multiple loader concurrently
+            write_job_result 'success', 'task is already processed by other jobs'
           elsif table_in_use
             write_job_error 'failure', "other jobs are working on the target table"
             success = false

--- a/lib/bricolage/streamingload/loader.rb
+++ b/lib/bricolage/streamingload/loader.rb
@@ -31,7 +31,7 @@ module Bricolage
       def execute
         @params.ds.open {|conn|
           @connection = conn
-          # Do nothing if task already running or succeeded
+          # Do nothing if the task already running or succeeded
           # Retry if error
           return if task_processed?(@params.task_seq)
           assign_task
@@ -119,7 +119,7 @@ module Bricolage
                 dwh_jobs t
             left outer join
                 dwh_job_results
-            using(dwh_job_seq)
+                using(dwh_job_seq)
             where
                 t.dwh_task_seq = #{task_seq}
                 and (

--- a/lib/bricolage/streamingload/loader.rb
+++ b/lib/bricolage/streamingload/loader.rb
@@ -60,7 +60,7 @@ module Bricolage
             success = false
           end
         }
-        raise JobFailure, "could not assign task: #{task.id}" unless success
+        raise JobFailure, "could not assign task: #{@params.task_id}" unless success
       end
 
       def do_load

--- a/lib/bricolage/streamingload/loader.rb
+++ b/lib/bricolage/streamingload/loader.rb
@@ -31,46 +31,35 @@ module Bricolage
       def execute
         @params.ds.open {|conn|
           @connection = conn
+          # Do nothing if task already running or succeeded
+          # Retry if error
+          return if task_processed?(@params.task_seq)
           assign_task
+          #FIXME unprocessed job remains if loader dies this here, before finishing load
+          #You can retry it by inserting result as error if the task message is still in sqs
           do_load
         }
       end
 
       def assign_task
-        success = true
         @connection.transaction {|txn|
-          @connection.lock('dwh_tasks')
-          @connection.lock('dwh_jobs')
-          @connection.lock('dwh_job_results')
-
-          already_processed = task_processed?(@params.task_seq)
-          table_in_use = table_in_use?(@params.schema, @params.table)
-
-          write_job(@params.task_seq)
-          @job_seq = read_job_seq(@job_id)
+          @job_seq = write_job(@params.task_seq)
           @logger.info "dwh_job_seq=#{@job_seq}"
-
-          # These result record MUST be written in the same transaction.
-          # DO NOT raise exception here
-          if already_processed
-            # Skip already processed task (may happen with second and later "duplicated" sqs messages)
-            #FIXME May leave object unprocessed when running multiple loader concurrently
-            write_job_result 'success', 'task is already processed by other jobs'
-          elsif table_in_use
-            write_job_error 'failure', "other jobs are working on the target table"
-            success = false
-          end
+          stage_files(@params.task_seq)
         }
-        raise JobFailure, "could not assign task: #{@params.task_id}" unless success
       end
 
       def do_load
-        staged_files = stage_files(@params.task_seq)
-        return if staged_files.empty?
+        files = staged_files
+        if files.empty?
+          @connection.transaction {
+            commit_job_result
+          }
+        end
         ManifestFile.create(
           @params.ctl_bucket,
           job_id: @job_id,
-          object_urls: staged_files,
+          object_urls: files,
           logger: @logger
         ) {|manifest|
           if @params.enable_work_table?
@@ -113,30 +102,29 @@ module Bricolage
                 )
             ;
         EndSQL
-      end
-
-      def read_job_seq(job_id)
-        @connection.query_value(<<-EndSQL)
+        job_seq = @connection.query_value(<<-EndSQL)
             select dwh_job_seq
             from dwh_jobs
-            where dwh_job_id = #{s job_id}
+            where dwh_job_id = #{s @job_id}
             ;
         EndSQL
+        job_seq
       end
 
       def task_processed?(task_seq)
         n_nonerror_jobs = @connection.query_value(<<-EndSQL)
             select
-                count(*)
+                count(distinct dwh_job_seq)
             from
-                dwh_tasks t
-                inner join dwh_jobs j using (dwh_task_seq)
-                left outer join dwh_job_results r using (dwh_job_seq)
+                dwh_jobs t
+            left outer join
+                dwh_job_results
+            using(dwh_job_seq)
             where
                 t.dwh_task_seq = #{task_seq}
                 and (
-                    r.status is null         -- running
-                    or r.status = 'success'  -- finished with success
+                    status is null -- runnnig
+                    or status = 'success'
                 )
             ;
         EndSQL
@@ -144,26 +132,9 @@ module Bricolage
         n_nonerror_jobs.to_i > 0
       end
 
-      def table_in_use?(schema, table)
-        n_working_jobs = @connection.query_value(<<-EndSQL)
-            select
-                count(*)
-            from
-                dwh_tasks t
-                inner join dwh_jobs j using (dwh_task_seq)
-                left outer join dwh_job_results r using (dwh_job_seq)
-            where
-                t.schema_name = #{s schema}
-                and t.table_name = #{s table}
-                and r.status is null   -- running
-            ;
-        EndSQL
-        @logger.debug "n_working_jobs=#{n_working_jobs.inspect}"
-        n_working_jobs.to_i > 0
-      end
-
       def stage_files(task_seq)
         # already-processed object_url MUST be removed
+        # retry errored objects
         @connection.execute(<<-EndSQL)
             insert into dwh_str_load_files
                 ( dwh_job_seq
@@ -172,22 +143,29 @@ module Bricolage
             select
                 #{@job_seq}
                 , object_url
-            from
-                dwh_str_load_files_incoming
-            where
-                dwh_task_seq = #{task_seq}
-                and object_url not in (
-                    select
-                        f.object_url
-                    from
-                        dwh_str_load_files f
-                        inner join dwh_job_results r using (dwh_job_seq)
-                    where
-                        r.status = 'success'
+            from (
+                select
+                    object_url
+                from
+                    dwh_str_load_files_incoming
+                where
+                    dwh_task_seq = #{task_seq}
+                except
+                select
+                    object_url
+                from
+                    dwh_str_load_files
+                left outer join
+                    dwh_job_results
+                using(dwh_job_seq)
+                where status is null -- runnnig
+                or status = 'success' -- success
                 )
             ;
         EndSQL
+      end
 
+      def staged_files
         staged_files = @connection.query_values(<<-EndSQL)
             select
                 object_url
@@ -198,7 +176,6 @@ module Bricolage
             ;
         EndSQL
         @logger.debug "n_staged_files=#{staged_files.size}"
-
         staged_files
       end
 

--- a/lib/bricolage/streamingload/loaderparams.rb
+++ b/lib/bricolage/streamingload/loaderparams.rb
@@ -8,27 +8,27 @@ module Bricolage
     class LoaderParams
 
       def LoaderParams.load(ctx, task)
-        job = load_job(ctx, task)
+        job = load_job(ctx, task.schema, task.table)
         job.provide_default 'dest-table', "#{task.schema}.#{task.table}"
         #job.provide_sql_file_by_job_id   # FIXME: provide only when exist
         job.compile
         new(task, job)
       end
 
-      def LoaderParams.load_job(ctx, task)
-        if job_file = find_job_file(ctx, task)
+      def LoaderParams.load_job(ctx, schema, table)
+        if job_file = find_job_file(ctx, schema, table)
           ctx.logger.debug "using .job file: #{job_file}"
-          Job.load_file(job_file, ctx.subsystem(task.schema))
+          Job.load_file(job_file, ctx.subsystem(schema))
         else
           ctx.logger.debug "using default job parameters (no .job file)"
-          Job.instantiate(task.table, 'streaming_load_v3', ctx).tap {|job|
+          Job.instantiate(table, 'streaming_load_v3', ctx).tap {|job|
             job.bind_parameters({})
           }
         end
       end
 
-      def LoaderParams.find_job_file(ctx, task)
-        paths = Dir.glob("#{ctx.home_path}/#{task.schema}/#{task.table}.*")
+      def LoaderParams.find_job_file(ctx, schema, table)
+        paths = Dir.glob("#{ctx.home_path}/#{schema}/#{table}.*")
         paths.select {|path| File.extname(path) == '.job' }.sort.first
       end
 
@@ -99,6 +99,8 @@ module Bricolage
         params.add SQLFileParam.new('sql-file', 'PATH', 'SQL to insert rows from the work table to the target table.', optional: true)
         params.add DataSourceParam.new('sql', 'redshift-ds', 'Target data source.')
         params.add DataSourceParam.new('s3', 'ctl-ds', 'Manifest file data source.')
+        params.add StringParam.new('buffer-size-limit', 'BUFFER_SIZE_LIMIT', 'Buffer size limit.', optional: true)
+        params.add StringParam.new('load-interval', 'LOAD_INTERVAL', 'Load interval is sec.', optional: true)
       end
 
       def self.default_load_options

--- a/lib/bricolage/streamingload/loaderparams.rb
+++ b/lib/bricolage/streamingload/loaderparams.rb
@@ -121,7 +121,6 @@ module Bricolage
       def self.declarations(params)
         Bricolage::Declarations.new(
           'dest_table' => nil,
-          'work_table' => nil
         )
       end
 

--- a/lib/bricolage/streamingload/loaderservice.rb
+++ b/lib/bricolage/streamingload/loaderservice.rb
@@ -19,6 +19,7 @@ module Bricolage
           exit 1
         end
         config_path, * = opts.rest_arguments
+        set_log_path opts.log_file_path if opts.log_file_path
 
         config = YAML.load(File.read(config_path))
 
@@ -39,7 +40,6 @@ module Bricolage
         else
           # Server mode
           Process.daemon(true) if opts.daemon?
-          set_log_file opts.log_file_path if opts.log_file_path
           create_pid_file opts.pid_file_path if opts.pid_file_path
           service.event_loop
         end

--- a/lib/bricolage/streamingload/loaderservice.rb
+++ b/lib/bricolage/streamingload/loaderservice.rb
@@ -45,7 +45,7 @@ module Bricolage
         end
       end
 
-      def Dispatcher.set_log_path(path)
+      def LoaderService.set_log_path(path)
         FileUtils.mkdir_p File.dirname(path)
         # make readable for retrieve_last_match_from_stderr
         File.open(path, 'w+') {|f|

--- a/lib/bricolage/streamingload/loaderservice.rb
+++ b/lib/bricolage/streamingload/loaderservice.rb
@@ -22,7 +22,7 @@ module Bricolage
 
         config = YAML.load(File.read(config_path))
 
-        ctx = Context.for_application('.')
+        ctx = Context.for_application('.', environment: opts.environment)
         redshift_ds = ctx.get_data_source('sql', config.fetch('redshift-ds'))
         task_queue = ctx.get_data_source('sqs', config.fetch('task-queue-ds'))
 
@@ -93,6 +93,9 @@ module Bricolage
         opts.on('--task-id=ID', 'Execute oneshot load task (implicitly disables daemon mode).') {|task_id|
           @task_id = task_id
         }
+        opts.on('-e', '--environment=NAME', "Sets execution environment [default: #{Context::DEFAULT_ENV}]") {|env|
+          @environment = env
+        }
         opts.on('--daemon', 'Becomes daemon in server mode.') {
           @daemon = true
         }
@@ -120,7 +123,7 @@ module Bricolage
         raise OptionError, err.message
       end
 
-      attr_reader :rest_arguments
+      attr_reader :rest_arguments, :environment
       attr_reader :task_id
 
       def daemon?

--- a/lib/bricolage/streamingload/objectbuffer.rb
+++ b/lib/bricolage/streamingload/objectbuffer.rb
@@ -184,6 +184,7 @@ module Bricolage
       end
 
       def head_url
+        return nil if empty?
         @buffer.first.url
       end
 

--- a/utils/init_strload_tables.sql
+++ b/utils/init_strload_tables.sql
@@ -1,0 +1,14 @@
+drop table if exists dwh_job_results;
+drop table if exists dwh_jobs;
+drop table if exists dwh_str_load_files;
+drop table if exists dwh_str_load_files_incoming;
+drop table if exists dwh_str_load_tables;
+drop table if exists dwh_tasks;
+
+\i schema/dwh_job_results.ct
+\i schema/dwh_jobs.ct
+\i schema/dwh_str_load_files.ct
+\i schema/dwh_str_load_files_incoming.ct
+\i schema/dwh_str_load_tables.ct
+\i schema/dwh_tasks.ct
+


### PR DESCRIPTION
### 1. 複数テーブルのタスクのインサートを1トランザクションで実行するように変更。

課題
テーブルごとに異なるトランザクションでタスクがインサートされているため、コミット回数が多い。コミットは待たされることが多いため、パフォーマンスが悪い。

対応
同じタイミングで実行されるタスクのインサートを1トランザクション化

### 2. テーブルごとのロードインターバルのサポート

課題
全テーブルが同じ間隔でロードされると、ロードが追いつかない場合がある

対応
テーブル毎にロード間隔を設定できるようにする