### PR TITLE
Use rake with bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    rake (11.1.2)
     redis (3.3.0)
     ruby-progressbar (1.7.5)
     rubyzip (1.1.7)
@@ -70,6 +71,7 @@ PLATFORMS
 DEPENDENCIES
   bricolage!
   pry
+  rake
   test-unit
 
 BUNDLED WITH

--- a/bricolage.gemspec
+++ b/bricolage.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'redis', ">= 3.0.0"
   s.add_development_dependency 'test-unit'
   s.add_development_dependency 'pry'
+  s.add_development_dependency 'rake'
 end


### PR DESCRIPTION
This commit fixes an error like

```
LoadError: cannot load such file -- bricolage/jobclass
```

when kick 'rake test'