### PR TITLE
Insert location as a block comment

### DIFF
--- a/lib/bricolage/psqldatasource.rb
+++ b/lib/bricolage/psqldatasource.rb
@@ -178,7 +178,7 @@ module Bricolage
       buf.puts '\timing on'
       each_statement do |stmt|
         buf.puts
-        buf.puts "-- #{stmt.location}" if stmt.location
+        buf.puts "/* #{stmt.location} */" if stmt.location
         buf.puts stmt.stripped_source
       end
       buf.string


### PR DESCRIPTION
With this change, we can see query locations in system catalogs like
pg_stat_activity or stv_inflight.