### PR TITLE
Add option to skip creating backup table

### DIFF
--- a/jobclass/my-import.rb
+++ b/jobclass/my-import.rb
@@ -18,7 +18,7 @@ JobClass.define('my-import') {
         optional: true, default: PSQLLoadOptions.new,
         value_handler: lambda {|value, ctx, vars| PSQLLoadOptions.parse(value) })
     params.add SQLFileParam.new('table-def', 'PATH', 'Create table file.')
-    params.add OptionalBoolParam.new('no-backup', 'Do not backup current table with prefix "_old".', default: false)
+    params.add OptionalBoolParam.new('no-backup', 'Do not backup current table with suffix "_old".', default: false)
 
     # Misc
     params.add OptionalBoolParam.new('analyze', 'ANALYZE table after SQL is executed.', default: true)
@@ -74,7 +74,7 @@ JobClass.define('my-import') {
         task.vacuum_if params['vacuum'], params['vacuum-sort'], load_target_table
         task.analyze_if params['analyze'], load_target_table
 
-        if load_target_table == work_table
+        unless params['no-backup']
           task.transaction {
             task.create_dummy_table '${dest_table}'
             task.rename_table params['dest-table'].to_s, "#{params['dest-table'].name}_old"

--- a/jobclass/my-import.rb
+++ b/jobclass/my-import.rb
@@ -54,33 +54,34 @@ JobClass.define('my-import') {
         prev_table = '${dest_table}_old'
         work_table = '${dest_table}_wk'
 
-        load_target_table = params['no-backup'] ? '${dest_table}' : work_table
-
         task.transaction {
-          # create
+          # CREATE
           task.drop_force prev_table
-          task.drop_force load_target_table
-          task.exec params['table-def'].replace(/\$\{?dest_table\}?\b/, load_target_table)
+          task.drop_force work_table
+          task.exec params['table-def'].replace(/\$\{?dest_table\}?\b/, work_table)
 
-          # copy
-          task.load params['s3-ds'], params['s3-prefix'], load_target_table,
+          # COPY
+          task.load params['s3-ds'], params['s3-prefix'], work_table,
               'json', nil, params['options'].merge('gzip' => params['gzip'])
 
-          # grant
-          task.grant_if params['grant'], load_target_table
+          # GRANT
+          task.grant_if params['grant'], work_table
         }
 
-        # vacuum, analyze
-        task.vacuum_if params['vacuum'], params['vacuum-sort'], load_target_table
-        task.analyze_if params['analyze'], load_target_table
+        # VACUUM, ANALYZE
+        task.vacuum_if params['vacuum'], params['vacuum-sort'], work_table
+        task.analyze_if params['analyze'], work_table
 
-        unless params['no-backup']
-          task.transaction {
+        # RENAME
+        task.transaction {
+          if params['no-backup']
+            task.drop_force params['dest-table'].to_s
+          else
             task.create_dummy_table '${dest_table}'
             task.rename_table params['dest-table'].to_s, "#{params['dest-table'].name}_old"
-            task.rename_table work_table, params['dest-table'].name
-          }
-        end
+          end
+          task.rename_table work_table, params['dest-table'].name
+        }
       }
     end
   }

--- a/jobclass/my-import.rb
+++ b/jobclass/my-import.rb
@@ -54,34 +54,33 @@ JobClass.define('my-import') {
         prev_table = '${dest_table}_old'
         work_table = '${dest_table}_wk'
 
-        task.transaction {
-          # CREATE
-          task.drop_force prev_table unless params['no-backup']
-          task.drop_force work_table
-          task.exec params['table-def'].replace(/\$\{?dest_table\}?\b/, work_table)
+        load_target_table = params['no-backup'] ? '${dest_table}' : work_table
 
-          # COPY
-          task.load params['s3-ds'], params['s3-prefix'], work_table,
+        task.transaction {
+          # create
+          task.drop_force prev_table
+          task.drop_force load_target_table
+          task.exec params['table-def'].replace(/\$\{?dest_table\}?\b/, load_target_table)
+
+          # copy
+          task.load params['s3-ds'], params['s3-prefix'], load_target_table,
               'json', nil, params['options'].merge('gzip' => params['gzip'])
 
-          # GRANT
-          task.grant_if params['grant'], work_table
+          # grant
+          task.grant_if params['grant'], load_target_table
         }
 
-        # VACUUM, ANALYZE
-        task.vacuum_if params['vacuum'], params['vacuum-sort'], work_table
-        task.analyze_if params['analyze'], work_table
+        # vacuum, analyze
+        task.vacuum_if params['vacuum'], params['vacuum-sort'], load_target_table
+        task.analyze_if params['analyze'], load_target_table
 
-        # RENAME
-        task.transaction {
-          if params['no-backup']
-            task.drop_force params['dest-table'].to_s
-          else
+        if load_target_table == work_table
+          task.transaction {
             task.create_dummy_table '${dest_table}'
             task.rename_table params['dest-table'].to_s, "#{params['dest-table'].name}_old"
-          end
-          task.rename_table work_table, params['dest-table'].name
-        }
+            task.rename_table work_table, params['dest-table'].name
+          }
+        end
       }
     end
   }

--- a/jobclass/my-migrate.rb
+++ b/jobclass/my-migrate.rb
@@ -22,7 +22,7 @@ JobClass.define('my-migrate') {
         optional: true, default: PSQLLoadOptions.new,
         value_handler: lambda {|value, ctx, vars| PSQLLoadOptions.parse(value) })
     params.add SQLFileParam.new('table-def', 'PATH', 'Create table file.')
-    params.add OptionalBoolParam.new('no-backup', 'Do not backup current table with prefix "_old".', default: false)
+    params.add OptionalBoolParam.new('no-backup', 'Do not backup current table with suffix "_old".', default: false)
 
     # Misc
     params.add OptionalBoolParam.new('analyze', 'ANALYZE table after SQL is executed.', default: true)
@@ -97,7 +97,7 @@ JobClass.define('my-migrate') {
         task.vacuum_if params['vacuum'], params['vacuum-sort'], load_target_table
         task.analyze_if params['analyze'], load_target_table
 
-        if load_target_table == work_table
+        unless params['no-backup']
           task.transaction {
             task.create_dummy_table '${dest_table}'
             task.rename_table params['dest-table'].to_s, "#{params['dest-table'].name}_old"

--- a/jobclass/my-migrate.rb
+++ b/jobclass/my-migrate.rb
@@ -76,34 +76,34 @@ JobClass.define('my-migrate') {
         prev_table = '${dest_table}_old'
         work_table = '${dest_table}_wk'
 
-        task.transaction {
-          # CREATE
-          task.drop_force prev_table unless params['no-backup']
-          task.drop_force work_table
-          task.exec params['table-def'].replace(/\$\{?dest_table\}?\b/, work_table)
+        load_target_table = params['no-backup'] ? '${dest_table}' : work_table
 
-          # COPY
-          task.load params['s3-ds'], params['s3-file'], work_table,
+        task.drop_force prev_table
+        task.transaction {
+          # create
+          task.drop_force prev_table
+          task.drop_force load_target_table
+          task.exec params['table-def'].replace(/\$\{?dest_table\}?\b/, load_target_table)
+
+          # copy
+          task.load params['s3-ds'], params['s3-file'], load_target_table,
               'json', nil, params['options'].merge('gzip' => params['gzip'])
 
-          # GRANT
-          task.grant_if params['grant'], work_table
+          # grant
+          task.grant_if params['grant'], load_target_table
         }
 
-        # VACUUM, ANALYZE
-        task.vacuum_if params['vacuum'], params['vacuum-sort'], work_table
-        task.analyze_if params['analyze'], work_table
+        # vacuum, analyze
+        task.vacuum_if params['vacuum'], params['vacuum-sort'], load_target_table
+        task.analyze_if params['analyze'], load_target_table
 
-        # RENAME
-        task.transaction {
-          if params['no-backup']
-            task.drop_force params['dest-table'].to_s
-          else
+        if load_target_table == work_table
+          task.transaction {
             task.create_dummy_table '${dest_table}'
             task.rename_table params['dest-table'].to_s, "#{params['dest-table'].name}_old"
-          end
-          task.rename_table work_table, params['dest-table'].name
-        }
+            task.rename_table work_table, params['dest-table'].name
+          }
+        end
       }
     end
   }

--- a/jobclass/my-migrate.rb
+++ b/jobclass/my-migrate.rb
@@ -22,6 +22,7 @@ JobClass.define('my-migrate') {
         optional: true, default: PSQLLoadOptions.new,
         value_handler: lambda {|value, ctx, vars| PSQLLoadOptions.parse(value) })
     params.add SQLFileParam.new('table-def', 'PATH', 'Create table file.')
+    params.add OptionalBoolParam.new('no-backup', 'Do not backup current table with prefix "_old".', default: false)
 
     # Misc
     params.add OptionalBoolParam.new('analyze', 'ANALYZE table after SQL is executed.', default: true)
@@ -77,7 +78,7 @@ JobClass.define('my-migrate') {
 
         task.transaction {
           # CREATE
-          task.drop_force prev_table
+          task.drop_force prev_table unless params['no-backup']
           task.drop_force work_table
           task.exec params['table-def'].replace(/\$\{?dest_table\}?\b/, work_table)
 
@@ -95,8 +96,12 @@ JobClass.define('my-migrate') {
 
         # RENAME
         task.transaction {
-          task.create_dummy_table '${dest_table}'
-          task.rename_table params['dest-table'].to_s, "#{params['dest-table'].name}_old"
+          if params['no-backup']
+            task.drop_force params['dest-table'].to_s
+          else
+            task.create_dummy_table '${dest_table}'
+            task.rename_table params['dest-table'].to_s, "#{params['dest-table'].name}_old"
+          end
           task.rename_table work_table, params['dest-table'].name
         }
       }

--- a/test/home/subsys/migrate.job
+++ b/test/home/subsys/migrate.job
@@ -1,5 +1,5 @@
 class: my-migrate
-src-ds: mysql
+src-ds: cookpad_main_db
 src-tables:
     search_backends: main.search_backends
 tmp-file: $data_dir/search_backends.json.gz
@@ -12,6 +12,7 @@ remove-tmp: true
 dest-ds: sql
 dest-table: $test_schema.search_backends
 table-def: search_backends.ct
+no-backup: true
 options:
     statupdate: false
     compupdate: false

--- a/test/home/subsys/migrate.job
+++ b/test/home/subsys/migrate.job
@@ -1,5 +1,5 @@
 class: my-migrate
-src-ds: cookpad_main_db
+src-ds: mysql
 src-tables:
     search_backends: main.search_backends
 tmp-file: $data_dir/search_backends.json.gz

--- a/test/home/subsys/my-import.job
+++ b/test/home/subsys/my-import.job
@@ -14,6 +14,7 @@ dump-options:
 dest-ds: sql
 dest-table: $test_schema.users
 table-def: users.ct
+no-backup: true
 options:
     statupdate: false
     compupdate: false

--- a/test/home/subsys/my-import.job
+++ b/test/home/subsys/my-import.job
@@ -14,7 +14,7 @@ dump-options:
 dest-ds: sql
 dest-table: $test_schema.users
 table-def: users.ct
-no-backup: true
+#no-backup: true
 options:
     statupdate: false
     compupdate: false


### PR DESCRIPTION
`my-import`と`migrate`に`no-backup`オプションを追加します。

現在は、ロード時に宛先テーブルを_oldプリフィクスを付けてバックアップする実装になっています。しかし、データ量を減らしたい場合や、テーブル数を減らしたい場合などは、_oldテーブルが作成されないほうが都合が良いです。このオプションを付けると、_oldテーブルを作成せずに、ロードを実行します。