### PR TITLE
Use asynchronous pg methods

### DIFF
--- a/lib/bricolage/application.rb
+++ b/lib/bricolage/application.rb
@@ -5,6 +5,7 @@ require 'bricolage/jobresult'
 require 'bricolage/variables'
 require 'bricolage/datasource'
 require 'bricolage/eventhandlers'
+require 'bricolage/postgresconnection'
 require 'bricolage/logger'
 require 'bricolage/exception'
 require 'bricolage/version'
@@ -14,12 +15,17 @@ require 'optparse'
 module Bricolage
 
   class Application
+    def Application.install_signal_handlers
+      Signal.trap('PIPE', 'IGNORE')
+      PostgresConnection.install_signal_handlers
+    end
+
     def Application.main
+      install_signal_handlers
       new.main
     end
 
     def initialize
-      Signal.trap('PIPE', 'IGNORE')
       @hooks = Bricolage
     end
 

--- a/lib/bricolage/commandlineapplication.rb
+++ b/lib/bricolage/commandlineapplication.rb
@@ -1,9 +1,11 @@
+require 'bricolage/application'
 require 'bricolage/context'
 require 'forwardable'
 
 module Bricolage
   class CommandLineApplication
     def CommandLineApplication.define
+      Application.install_signal_handlers
       opts = new
       yield opts
       opts.parse!

--- a/lib/bricolage/jobnetrunner.rb
+++ b/lib/bricolage/jobnetrunner.rb
@@ -17,11 +17,11 @@ module Bricolage
 
   class JobNetRunner
     def JobNetRunner.main
+      Application.install_signal_handlers
       new.main
     end
 
     def initialize
-      Signal.trap('PIPE', 'IGNORE')
       @hooks = ::Bricolage
       @jobnet_id = nil
       @jobnet_start_time = Time.now

--- a/lib/bricolage/postgresconnection.rb
+++ b/lib/bricolage/postgresconnection.rb
@@ -123,6 +123,10 @@ module Bricolage
       execute_query(query) {|rs| rs.to_a.first }
     end
 
+    def query_rows(query)
+      execute_query(query) {|rs| rs.to_a }
+    end
+
     def execute_query(query, &block)
       log_query query
       rs = log_elapsed_time {


### PR DESCRIPTION
pgの同期系メソッドを使うとシグナルがすべてブロックされるので、async_execに変更した。同時に、クエリー実行中にシグナルに割り込まれたらクエリーを明示的にキャンセルするようにした。

なお、SIGTERMを正しく拾うためにはシグナルハンドラのインストールが必要なので、Bricolageアプリケーションの場合のみシグナルハンドラを設定する（条件はいくらか控えめにした）。