### PR TITLE
Support timezone conversion with my-import

### DIFF
--- a/lib/bricolage/mysqldatasource.rb
+++ b/lib/bricolage/mysqldatasource.rb
@@ -183,7 +183,9 @@ module Bricolage
         write_concurrency: options['write_concurrency'],
         rotation_size: options['rotation_size'],
         delete_objects: options['delete_objects'],
-        object_key_delimiter: options['object_key_delimiter'])
+        object_key_delimiter: options['object_key_delimiter'],
+        src_zone_offset: options['src_zone_offset'],
+        dst_zone_offset: options['dst_zone_offset'])
     end
 
     class S3Export < Action
@@ -195,7 +197,9 @@ module Bricolage
          write_concurrency: 4,
          rotation_size: nil,
          delete_objects: false,
-         object_key_delimiter: nil)
+         object_key_delimiter: nil,
+         src_zone_offset: nil,
+         dst_zone_offset: nil)
         @table = table
         @statement = stmt
         @s3ds = s3ds
@@ -208,6 +212,8 @@ module Bricolage
         @rotation_size = rotation_size
         @delete_objects = delete_objects
         @object_key_delimiter = object_key_delimiter
+        @src_zone_offset = src_zone_offset
+        @dst_zone_offset = dst_zone_offset
       end
 
       def run
@@ -250,6 +256,12 @@ module Bricolage
         params[:r] = @rotation_size if @rotation_size
         params[:d] = nil if @delete_objects
         params[:k] = @object_key_delimiter if @object_key_delimiter
+        if src_zone_offset = @src_zone_offset || ds.mysql_options[:src_zone_offset]
+          params[:S] = src_zone_offset
+        end
+        if dst_zone_offset = @dst_zone_offset || ds.mysql_options[:dst_zone_offset]
+          params[:T] = dst_zone_offset
+        end
         params
       end
 

--- a/test/home/subsys/my-import.job
+++ b/test/home/subsys/my-import.job
@@ -6,10 +6,8 @@ s3-ds: s3
 s3-prefix: shimpeko/test-abc-
 gzip: true
 dump-options:
-    partition_column: id
-    partition_number: 8
-    write_concurrency: 16
-    rotation_size: 16000000
+    src_zone_offset: "+00:00"
+    dst_zone_offset: "+09:00"
     delete_objects: true
 dest-ds: sql
 dest-table: $test_schema.users


### PR DESCRIPTION
my-importジョブクラスでtimezoneの変換をサポートします。

データソース設定ファイルまたはジョブファイルで、`src_zone_offset`および`dst_zone_offset`を定義すると、MySQLでTIMESTAMP型またDATETIME型として定義されているカラムのタイムゾーン（GMTからのオフセット）を変換します。

MySQLのTIMESTAMP型およびDATETIME型はタイムゾーン情報を保持していないため、`src_zone_offset`を基準として変換を行います。デフォルトの`src_zone_offset`は+00:00です。

srcがdstと等しい場合は変換を行いません。

@aamine please review