### PR TITLE
Enable debug log for S3 access to investigate error

### DIFF
--- a/lib/bricolage/s3datasource.rb
+++ b/lib/bricolage/s3datasource.rb
@@ -103,7 +103,7 @@ module Bricolage
     #
 
     def client
-      @client ||= Aws::S3::Client.new(region: @region, endpoint: @endpoint, access_key_id: access_key, secret_access_key: secret_key)
+      @client ||= Aws::S3::Client.new(region: @region, endpoint: @endpoint, access_key_id: access_key, secret_access_key: secret_key, logger: logger, log_level: :debug, http_wire_trace: true)
     end
 
     def bucket


### PR DESCRIPTION
エラー調査のためエラーログを一時的に有効化します。
本番からこのブランチを参照する予定です。

ログ出力量のさっくり見積もり: 128KB * (60/5)*24 = 約40MB/日

ログ出力量内訳
- オブジェクト一覧GET: 50KB
- ロード対象CSV PUT 4KB
- マニフェスト PUT: 4KB
- オブジェクト移動（PUT/DEL）: 80KB

@aamine please review

