### PR TITLE
Enable collation option for JDBC connection property

### DIFF
--- a/lib/bricolage/mysqldatasource.rb
+++ b/lib/bricolage/mysqldatasource.rb
@@ -269,7 +269,8 @@ module Bricolage
         encoding: 'useUnicode=true&characterEncoding',
         read_timeout: 'netTimeoutForStreamingResults',
         connect_timeout: 'connectTimeout',
-        reconnect: 'autoReconnect'
+        reconnect: 'autoReconnect',
+        collation: 'connectionCollation'
       }
 
       def connection_property


### PR DESCRIPTION
MySQLのデータソース定義で、collationというJDBCの接続プロパティを設定出来るようにします。

@aamine 