### PR TITLE
my-migrate, my-import: Do not drop old tables in the RENAME transaction

### DIFF
--- a/jobclass/my-import.rb
+++ b/jobclass/my-import.rb
@@ -64,24 +64,20 @@ JobClass.define('my-import') {
           task.load params['s3-ds'], params['s3-prefix'], work_table,
               'json', nil, params['options'].merge('gzip' => params['gzip'])
 
-          # GRANT
+          # GRANT, ANALYZE
           task.grant_if params['grant'], work_table
-        }
+          task.analyze_if params['analyze'], work_table
 
-        # VACUUM, ANALYZE
-        task.vacuum_if params['vacuum'], params['vacuum-sort'], work_table
-        task.analyze_if params['analyze'], work_table
-
-        # RENAME
-        task.transaction {
-          if params['no-backup']
-            task.drop_force params['dest-table'].to_s
-          else
-            task.create_dummy_table '${dest_table}'
-            task.rename_table params['dest-table'].to_s, "#{params['dest-table'].name}_old"
-          end
+          # RENAME
+          task.create_dummy_table '${dest_table}'
+          task.rename_table params['dest-table'].to_s, "#{params['dest-table'].name}_old"
           task.rename_table work_table, params['dest-table'].name
         }
+
+        task.drop_force prev_table if params['no-backup']
+
+        # VACUUM: vacuum is needless for newly created table, applying vacuum after exposure is not a problem.
+        task.vacuum_if params['vacuum'], params['vacuum-sort'], params['dest-table'].to_s
       }
     end
   }


### PR DESCRIPTION
既存テーブルを新しいテーブルとトランザクションの中ですりかえるとき、既存テーブルをdropしてしまうと、すでに実行中のトランザクションからテーブルがdropされたことが見えてしまい、"table dropped in concurrent transaction" のエラーになる。

ref: http://stackoverflow.com/questions/20692518/how-can-i-ensure-synchronous-ddl-operations-on-a-table-that-is-being-replaced

このエラーを回避するためには、dropを別トランザクションで実施しなければならない。
