### PR TITLE
Treat as jobnet contains the single job if passed *.job file

### DIFF
--- a/lib/bricolage/jobnet.rb
+++ b/lib/bricolage/jobnet.rb
@@ -357,7 +357,12 @@ module Bricolage
       end
 
       def JobNetRef.for_job_path(path)
-        new(path.parent.basename, path.basename('.job'), Location.dummy)
+        basename = path
+        # remove all extnames
+        until (ext = basename.extname).empty?
+          basename = basename.basename(ext)
+        end
+        new(path.parent.basename, basename, Location.dummy)
       end
 
       def initialize(subsys, name, location)

--- a/lib/bricolage/jobnetrunner.rb
+++ b/lib/bricolage/jobnetrunner.rb
@@ -39,7 +39,12 @@ module Bricolage
       @ctx = Context.for_application(nil, opts.jobnet_file, environment: opts.environment, global_variables: opts.global_variables)
       @jobnet_id = "#{opts.jobnet_file.dirname.basename}/#{opts.jobnet_file.basename('.jobnet')}"
       @log_path = opts.log_path
-      jobnet = RootJobNet.load(@ctx, opts.jobnet_file)
+      jobnet =
+        if opts.jobnet_file.extname == '.job'
+          RootJobNet.load_single_job(@ctx, opts.jobnet_file)
+        else
+          RootJobNet.load(@ctx, opts.jobnet_file)
+        end
       queue = get_queue(opts)
       if queue.locked?
         raise ParameterError, "Job queue is still locked. If you are sure to restart jobnet, #{queue.unlock_help}"


### PR DESCRIPTION
bricolage-jobnet で .job ファイル渡されたらジョブ1つだけのジョブネット扱いにします。

[lib/bricolage/jobnetrunner.rb#L40](https://github.com/KOBA789/bricolage/blob/5a9912c563ed48fbc8bc035dc9598c97d907503d/lib/bricolage/jobnetrunner.rb#L40) で `.job` は削らず、`.jobnet` しか削ってないのは、basename 部が同名の job と jobnet があった場合(考えたくないが)にログファイルの名前などを衝突させないためです。
この辺は設計(思想)上の判断が必要だと思うので、適宜指摘をお願いします。