### PR TITLE
Introduce new log file options

### DIFF
--- a/lib/bricolage/context.rb
+++ b/lib/bricolage/context.rb
@@ -68,6 +68,10 @@ module Bricolage
         logger: @logger)
     end
 
+    def subsystem_name
+      @filesystem.scope
+    end
+
     extend Forwardable
     def_delegators '@filesystem',
       :scoped?,

--- a/lib/bricolage/filesystem.rb
+++ b/lib/bricolage/filesystem.rb
@@ -36,6 +36,10 @@ module Bricolage
       false
     end
 
+    def scope
+      nil
+    end
+
     attr_reader :path
     attr_reader :environment
 
@@ -156,6 +160,10 @@ module Bricolage
 
     def scoped?
       true
+    end
+
+    def scope
+      @id
     end
 
     def root

--- a/lib/bricolage/job.rb
+++ b/lib/bricolage/job.rb
@@ -50,6 +50,10 @@ module Bricolage
       @job_class.id
     end
 
+    def subsystem
+      @context.subsystem_name
+    end
+
     def init_global_variables
       # Context#global_variables loads file on each call, fix global variables here.
       @global_variables = @context.global_variables

--- a/lib/bricolage/logfilepath.rb
+++ b/lib/bricolage/logfilepath.rb
@@ -1,0 +1,76 @@
+module Bricolage
+  class LogFilePath
+    def LogFilePath.default
+      if dir = ENV['BRICOLAGE_LOG_DIR']
+        new("#{dir}/%{std}.log")
+      elsif path = ENV['BRICOLAGE_LOG_PATH']
+        new(path)
+      else
+        nil
+      end
+    end
+
+    def initialize(template)
+      @template = template
+    end
+
+    Params = Struct.new(:job_ref, :jobnet_id, :job_start_time, :jobnet_start_time)
+
+    def format(job_ref:, jobnet_id:, job_start_time:, jobnet_start_time:)
+      return nil unless @template
+      params = Params.new(job_ref, jobnet_id, job_start_time, jobnet_start_time)
+      fill_template(@template, params)
+    end
+
+    def fill_template(template, params)
+      template.gsub(/%\{\w+\}/) {|var|
+        case var
+        when '%{std}' then standard_format(params)
+        when '%{jobnet_start_date}' then jobnet_start_date(params)
+        when '%{jobnet_start_time}' then jobnet_start_time(params)
+        when '%{job_start_date}' then job_start_date(params)
+        when '%{job_start_time}' then job_start_time(params)
+        when '%{jobnet}', '%{net}', '%{jobnet_id}', '%{net_id}', '%{flow}', '%{flow_id}' then jobnet_id(params)
+        when '%{subsystem}' then subsystem_name(params)
+        when '%{job}', '%{job_id}' then job_name(params)
+        else
+          raise ParameterError, "bad log path variable: #{var}"
+        end
+      }
+    end
+
+    STD_TEMPLATE = '%{jobnet_start_date}/%{jobnet}/%{jobnet_start_time}/%{subsystem}-%{job}'
+
+    def standard_format(params)
+      fill_template(STD_TEMPLATE, params)
+    end
+
+    def jobnet_start_date(params)
+      params.jobnet_start_time.strftime('%Y%m%d')
+    end
+
+    def jobnet_start_time(params)
+      params.jobnet_start_time.strftime('%Y%m%d_%H%M%S%L')
+    end
+
+    def job_start_date(params)
+      params.start_time.strftime('%Y%m%d')
+    end
+
+    def job_start_time(params)
+      params.start_time.strftime('%Y%m%d_%H%M%S%L')
+    end
+
+    def jobnet_id(params)
+      params.jobnet_id.gsub('/', '::')
+    end
+
+    def subsystem_name(params)
+      params.job_ref.subsystem
+    end
+
+    def job_name(params)
+      params.job_ref.name
+    end
+  end
+end

--- a/test/test_logfilepath.rb
+++ b/test/test_logfilepath.rb
@@ -1,0 +1,19 @@
+require 'test/unit'
+require 'bricolage/logfilepath'
+require 'bricolage/jobnet'
+
+module Bricolage
+  class TestLogFilePath < Test::Unit::TestCase
+    test '#format' do
+      path = LogFilePath.new('./log/%{std}.log')
+      ref = JobNet::JobRef.new('subsys', 'somejob', '-')
+      start = Time.new(2012,3,4,12,34,56)
+      assert_equal './log/20120304/subsys::rebuild/20120304_123456000/subsys-somejob.log', path.format(
+        job_ref: ref,
+        jobnet_id: 'subsys/rebuild',
+        job_start_time: start,
+        jobnet_start_time: start
+      )
+    end
+  end
+end


### PR DESCRIPTION
- bricolage: new option --log-path.
- bricolage, bricolage-jobnet: new option --log-dir.
- bricolage, bricolage-jobnet: new env BRICOLAGE_LOG_PATH.
- bricolage, bricolage-jobnet: new env BRICOLAGE_LOG_DIR.
- new log path format: %{std}

bricolageコマンドにも `--log-path` オプションを付けた。

新しいオプション `--log-dir` を導入した。`--log-dir=PREFIX` は `--log-path=PREFIX/%{std}.log` に等しい。 `%{std}` は `%{jobnet_start_date}/%{jobnet}/%{jobnet_start_time}/%{subsystem}-%{job}` に等しい。

BRICOLAGE_LOG_PATH環境変数は `--log-path` と同じ。

BRICOLAGE_LOG_DIR環境変数は `--log-dir` と同じ。

ref: #52 