### PR TITLE
fix: If a .rb.job file does not contain shebang line (#!), it wrongly fails to parse parameter block

### DIFF
--- a/lib/bricolage/jobfile.rb
+++ b/lib/bricolage/jobfile.rb
@@ -85,7 +85,7 @@ module Bricolage
         if first_line.start_with?('#!')
           yaml_lines = []
         else
-          yaml_lines = [first_line]
+          yaml_lines = [first_line[1..-1]]
         end
         script.each_line do |line|
           break unless line.start_with?('#')


### PR DESCRIPTION
.rb.jobファイルにshebang行がないとき、パラメーターブロックの1行目に `#` が付いたままになって壊れる問題があった。